### PR TITLE
Make logger interface public

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -65,7 +65,7 @@ type Conn struct {
 
 	delegate ConnDelegate
 
-	logger logger
+	logger Logger
 	logLvl LogLevel
 	logFmt string
 
@@ -120,7 +120,7 @@ func NewConn(addr string, config *Config, delegate ConnDelegate) *Conn {
 //
 //    Output(calldepth int, s string)
 //
-func (c *Conn) SetLogger(l logger, lvl LogLevel, format string) {
+func (c *Conn) SetLogger(l Logger, lvl LogLevel, format string) {
 	c.logger = l
 	c.logLvl = lvl
 	c.logFmt = format

--- a/consumer.go
+++ b/consumer.go
@@ -71,7 +71,7 @@ type Consumer struct {
 
 	mtx sync.RWMutex
 
-	logger logger
+	logger Logger
 	logLvl LogLevel
 
 	id      int64
@@ -173,7 +173,7 @@ func (r *Consumer) conns() []*Conn {
 //
 //    Output(calldepth int, s string)
 //
-func (r *Consumer) SetLogger(l logger, lvl LogLevel) {
+func (r *Consumer) SetLogger(l Logger, lvl LogLevel) {
 	r.logger = l
 	r.logLvl = lvl
 }

--- a/delegates.go
+++ b/delegates.go
@@ -5,7 +5,7 @@ import "time"
 // LogLevel specifies the severity of a given log message
 type LogLevel int
 
-type logger interface {
+type Logger interface {
 	Output(calldepth int, s string) error
 }
 

--- a/producer.go
+++ b/producer.go
@@ -20,7 +20,7 @@ type Producer struct {
 	conn   *Conn
 	config Config
 
-	logger logger
+	logger Logger
 	logLvl LogLevel
 
 	responseChan chan []byte
@@ -90,7 +90,7 @@ func NewProducer(addr string, config *Config) (*Producer, error) {
 //
 //    Output(calldepth int, s string)
 //
-func (w *Producer) SetLogger(l logger, lvl LogLevel) {
+func (w *Producer) SetLogger(l Logger, lvl LogLevel) {
 	w.logger = l
 	w.logLvl = lvl
 }


### PR DESCRIPTION
In my code, I'm using the SetLogger call, and to mock the Consumers/Producer
im using by wrapping each in their own interface. To do this, I need the
logger interface public so I can put SetLogger into my interface.