### PR TITLE
panic: runtime error: close of closed channel

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -123,6 +123,7 @@ type Consumer struct {
 	stopFlag        int32
 	connectedFlag   int32
 	stopHandler     sync.Once
+	exitHandler     sync.Once
 
 	// read from this channel to block until consumer is cleanly stopped
 	StopChan chan int
@@ -1079,9 +1080,11 @@ func (r *Consumer) shouldFailMessage(message *Message, handler interface{}) bool
 }
 
 func (r *Consumer) exit() {
-	close(r.exitChan)
-	r.wg.Wait()
-	close(r.StopChan)
+	r.exitHandler.Do(func() {
+		close(r.exitChan)
+		r.wg.Wait()
+		close(r.StopChan)
+	})
 }
 
 func (r *Consumer) log(lvl LogLevel, line string, args ...interface{}) {


### PR DESCRIPTION
I'm guessing this is user error, but I'm getting a panic when stopping a consumer as of this commit: 4e74fa1f8933064a4f04786e65d3ee7b611be598. Reading the comment in there, I'm trying to understand what's going on.

My shutdown code looks something like this:

```go
func (n *NSQPeer) Teardown() {
	n.producer.Stop()
	if n.consumer != nil {
		n.consumer.DisconnectFromNSQD(n.host)
		n.consumer.Stop()
		<-n.consumer.StopChan
	}
}
```

Here's the error:

```
runtime.panic(0x509600, 0x84c1d5)
        /usr/local/Cellar/go/1.3/libexec/src/pkg/runtime/panic.c:279 +0xf5
github.com/bitly/go-nsq.(*Consumer).exit(0xc20800ef00)
        /Users/tylertreat/Go/src/github.com/bitly/go-nsq/consumer.go:1082 +0x2e
github.com/bitly/go-nsq.func·007()
        /Users/tylertreat/Go/src/github.com/bitly/go-nsq/consumer.go:990 +0x29
created by time.goFunc
        /usr/local/Cellar/go/1.3/libexec/src/pkg/time/sleep.go:121 +0x47
```

Can anyone provide some insight on why I'm seeing this now?