### PR TITLE
consumer: Only add host address once on connection.

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -496,7 +496,9 @@ func (r *Consumer) ConnectToNSQD(addr string) error {
 	if !pendingOk {
 		r.pendingConnections[addr] = conn
 	}
-	r.nsqdTCPAddrs = append(r.nsqdTCPAddrs, addr)
+	if idx := indexOf(addr, r.nsqdTCPAddrs); idx == -1 {
+		r.nsqdTCPAddrs = append(r.nsqdTCPAddrs, addr)
+	}
 	r.mtx.Unlock()
 
 	r.log(LogLevelInfo, "(%s) connecting to nsqd", addr)


### PR DESCRIPTION
When specifying `nsqd` addresses directly, upon reconnecting, the address was being duplicated in `nsqdTCPAddrs`