### PR TITLE
Fix bounds err when removing lookupds

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -381,6 +381,9 @@ exit:
 // keeping track of which one was last used
 func (r *Consumer) nextLookupdEndpoint() string {
 	r.mtx.RLock()
+	if r.lookupdQueryIndex >= len(r.lookupdHTTPAddrs) {
+		r.lookupdQueryIndex = 0
+	}
 	addr := r.lookupdHTTPAddrs[r.lookupdQueryIndex]
 	num := len(r.lookupdHTTPAddrs)
 	r.mtx.RUnlock()


### PR DESCRIPTION
When removing lookupds, `r.lookupdQueryIndex` may become greater than `len(r.lookupdHTTPAddrs)`. This can cause a panic by index out of bounds error.