### PR TITLE
Producer: Adds a Ping method

### DIFF
--- a/producer.go
+++ b/producer.go
@@ -82,6 +82,11 @@ func NewProducer(addr string, config *Config) (*Producer, error) {
 	return p, nil
 }
 
+// Ping synchronously sends a Ping command to the configured nsqd, returning an error if the command failed
+func (w *Producer) Ping() error {
+	return w.sendCommand(Ping())
+}
+
 // SetLogger assigns the logger to use as well as a level
 //
 // The logger parameter is an interface that requires the following

--- a/producer_test.go
+++ b/producer_test.go
@@ -55,6 +55,27 @@ func TestProducerConnection(t *testing.T) {
 	}
 }
 
+func TestProducerPing(t *testing.T) {
+	log.SetOutput(ioutil.Discard)
+	defer log.SetOutput(os.Stdout)
+
+	config := NewConfig()
+	w, _ := NewProducer("127.0.0.1:4150", config)
+	w.SetLogger(nullLogger, LogLevelInfo)
+
+	err := w.Ping()
+	if err != nil {
+		t.Fatalf("should connect on ping")
+	}
+
+	w.Stop()
+
+	err = w.Ping("write_test", []byte("fail test"))
+	if err != ErrStopped {
+		t.Fatalf("should not be able to ping after Stop()")
+	}
+}
+
 func TestProducerPublish(t *testing.T) {
 	log.SetOutput(ioutil.Discard)
 	defer log.SetOutput(os.Stdout)


### PR DESCRIPTION
Adding a Ping method to the Producer allows for testing a Producer's nsqd connection w/o publishing any messages to a topic.

We've found it to be useful for failing fast when configuring Producers (since otherwise, the connections are made lazily on Publish), so I thought I'd see if it's a PR you want to merge in.