### PR TITLE
consumer: resolved addresses and reconnects

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -795,7 +795,7 @@ func (r *Consumer) onConnClose(c *Conn) {
 				}
 				break
 			}
-		}(c.RemoteAddr().String())
+		}(c.String())
 	}
 }
 


### PR DESCRIPTION
nsq_to_nsq unexpectedly quit, and I have copious logs:

nsq_to_nsq run file:
```
#!/bin/sh
exec 2>&1
 
export GOMAXPROCS=2
 
exec chpst -u nsq:nsq /opt/nsq/bin/nsq_to_nsq \
    -topic=logs \
    -destination-topic=logs \
    -destination-nsqd-tcp-address=this.is.a.cname.net:543 \
      -nsqd-tcp-address=localhost:543 \
    -channel=nsq_to_nsq \
    -consumer-opt=tls_root_ca_file,/opt/nsq/certs/ca-cert.pem \
    -consumer-opt=tls_cert,/opt/nsq/certs/client-cert.pem \
    -consumer-opt=tls_key,/opt/nsq/certs/client-key.pem \
    -consumer-opt=tls_v1,true \
    -producer-opt=tls_root_ca_file,/opt/nsq/certs/ca-cert.pem \
    -producer-opt=tls_cert,/opt/nsq/certs/client-cert.pem \
    -producer-opt=tls_key,/opt/nsq/certs/client-key.pem \
    -producer-opt=tls_v1,true \
    -producer-opt=tls_min_version,tls1.2
```

nsqd run file:
```
#!/bin/sh
exec 2>&1
 
export GOMAXPROCS=2
 
exec chpst -u nsq:nsq /opt/nsq/bin/nsqd \
    -tcp-address=0.0.0.0:543 \
    -http-address=0.0.0.0:544 \
    -https-address=0.0.0.0:545 \
    -broadcast-address=myserver-2 \
    -max-msg-size=5242880 \
    -mem-queue-size=0 \
    -e2e-processing-latency-percentile=1.0,0.99,0.95 \
    -e2e-processing-latency-window-time=10m0s \
    -data-path=/var/spool/nsqd/logs \
    -tls-root-ca-file=/opt/nsq/certs/ca-cert.pem \
    -tls-cert=/opt/nsq/certs/server-cert.pem \
    -tls-key=/opt/nsq/certs/server-key.pem \
    -tls-required=true \
    -tls-client-auth-policy=require-verify \
    -tls-min-version=tls1.2
```

nsq_to_nsq logs:
```
06:35:25 INF    1 [logs/nsq_to_nsq] stopping...
06:35:25 INF    1 [logs/nsq_to_nsq] stopping handlers
06:35:25 INF    1 [logs/nsq_to_nsq] rdyLoop exiting
06:35:27 INF    1 [logs/nsq_to_nsq] (localhost:543) connecting to nsqd
06:35:27 INF    1 [logs/nsq_to_nsq] (localhost:543) upgrading to TLS
06:35:28 INF    2 (this.is.a.cname.net:543) connecting to nsqd
06:35:29 ERR    2 (this.is.a.cname.net:543) error connecting to nsqd - dial tcp 8.8.8.8:543: i/o timeout
06:35:29 ERR    1 [logs/nsq_to_nsq] Handler return	ed error (dial tcp 8.8.8.8:543: i/o timeout) for msg 07d0d6da03130011
06:35:29 INF    2 (this.is.a.cname.net:543) connecting to nsqd
06:35:29 WRN    1 [logs/nsq_to_nsq] backing off for 2.0000 seconds (backoff level 1), setting all to RDY 0
06:35:30 ERR    2 (this.is.a.cname.net:543) error connecting to nsqd - dial tcp 8.8.8.8:543: i/o timeout
06:35:30 ERR    1 [logs/nsq_to_nsq] Handler returned error (dial tcp 8.8.8.8:543: i/o timeout) for msg 07d0d6da03130012
06:35:30 INF    2 (this.is.a.cname.net:543) connecting to nsqd
06:35:31 WRN    1 [logs/nsq_to_nsq] (localhost:543) backoff timeout expired, sending RDY 1
06:35:31 ERR    2 (this.is.a.cname.net:543) error connecting to nsqd - dial tcp 8.8.8.8:543: i/o timeout
06:35:31 ERR    1 [logs/nsq_to_nsq] Handler returned error (dial tcp 8.8.8.8:543: i/o timeout) for msg 07d0d6da03130013
06:35:31 INF    2 (this.is.a.cname.net:543) connecting to nsqd
06:35:31 WRN    1 [logs/nsq_to_nsq] backing off for 4.0000 seconds (backoff level 2), setting all to RDY 0
06:35:32 ERR    2 (this.is.a.cname.net:543) error connecting to nsqd - dial tcp 8.8.8.8:543: i/o timeout
06:35:32 ERR    1 [logs/nsq_to_nsq] Handler returned error (dial tcp 8.8.8.8:543: i/o timeout) for msg 07d0d6da03130014
06:35:32 INF    2 (this.is.a.cname.net:543) connecting to nsqd
06:35:33 ERR    2 (this.is.a.cname.net:543) error connecting to nsqd - dial tcp 8.8.8.8:543: i/o timeout
06:35:33 ERR    1 [logs/nsq_to_nsq] Handler returned error (dial tcp 8.8.8.8:543: i/o timeout) for msg 07d0d6da03130015
06:35:33 INF    2 (this.is.a.cname.net:543) connecting to nsqd
06:35:34 ERR    2 (this.is.a.cname.net:543) error connecting to nsqd - dial tcp 8.8.8.8:543: i/o timeout
06:35:34 ERR    1 [logs/nsq_to_nsq] Handler returned error (dial tcp 8.8.8.8:543: i/o timeout) for msg 07d0d6da03130016
06:35:34 INF    2 (this.is.a.cname.net:543) connecting to nsqd
06:35:35 WRN    1 [logs/nsq_to_nsq] (localhost:543) backoff timeout expired, sending RDY 1
06:35:35 ERR    2 (this.is.a.cname.net:543) error connecting to nsqd - dial tcp 8.8.8.8:543: i/o timeout
06:35:35 ERR    1 [logs/nsq_to_nsq] Handler returned error (dial tcp 8.8.8.8:543: i/o timeout) for msg 07d0d6da03130017
06:35:35 INF    2 (this.is.a.cname.net:543) connecting to nsqd
06:35:35 WRN    1 [logs/nsq_to_nsq] backing off for 8.0000 seconds (backoff level 3), setting all to RDY 0
06:35:36 ERR    2 (this.is.a.cname.net:543) error connecting to nsqd - dial tcp 8.8.8.8:543: i/o timeout
06:35:36 ERR    1 [logs/nsq_to_nsq] Handler returned error (dial tcp 8.8.8.8:543: i/o timeout) for msg 07d0d6da03130018
06:35:36 INF    2 (this.is.a.cname.net:543) connecting to nsqd
06:35:37 ERR    2 (this.is.a.cname.net:543) error connecting to nsqd - dial tcp 8.8.8.8:543: i/o timeout
06:35:37 ERR    1 [logs/nsq_to_nsq] Handler returned error (dial tcp 8.8.8.8:543: i/o timeout) for msg 07d0d6da03130019
06:35:37 INF    2 (this.is.a.cname.net:543) connecting to nsqd
06:35:38 ERR    2 (this.is.a.cname.net:543) error connecting to nsqd - dial tcp 8.8.8.8:543: i/o timeout
06:35:38 ERR    1 [logs/nsq_to_nsq] Handler returned error (dial tcp 8.8.8.8:543: i/o timeout) for msg 07d0d6da0313001a
06:35:38 INF    2 (this.is.a.cname.net:543) connecting to nsqd
06:35:39 ERR    2 (this.is.a.cname.net:543) error connecting to nsqd - dial tcp 8.8.8.8:543: i/o timeout
06:35:39 ERR    1 [logs/nsq_to_nsq] Handler returned error (dial tcp 8.8.8.8:543: i/o timeout) for msg 07d0d6da0313001b
06:35:39 INF    2 (this.is.a.cname.net:543) connecting to nsqd
06:35:40 ERR    2 (this.is.a.cname.net:543) error connecting to nsqd - dial tcp 8.8.8.8:543: i/o timeout
06:35:40 ERR    1 [logs/nsq_to_nsq] Handler returned error (dial tcp 8.8.8.8:543: i/o timeout) for msg 07d0d6da0313001c
06:35:40 INF    2 (this.is.a.cname.net:543) connecting to nsqd
06:35:41 ERR    2 (this.is.a.cname.net:543) error connecting to nsqd - dial tcp 8.8.8.8:543: i/o timeout
06:35:41 ERR    1 [logs/nsq_to_nsq] Handler returned error (dial tcp 8.8.8.8:543: i/o timeout) for msg 07d0d6da0313001d
06:35:41 INF    2 (this.is.a.cname.net:543) connecting to nsqd
06:35:42 ERR    2 (this.is.a.cname.net:543) error connecting to nsqd - dial tcp 8.8.8.8:543: i/o timeout
06:35:42 ERR    1 [logs/nsq_to_nsq] Handler returned error (dial tcp 8.8.8.8:543: i/o timeout) for msg 07d0d6da0313001e
06:35:42 INF    2 (this.is.a.cname.net:543) connecting to nsqd
06:35:43 WRN    1 [logs/nsq_to_nsq] (localhost:543) backoff timeout expired, sending RDY 1
06:35:43 ERR    2 (this.is.a.cname.net:543) error connecting to nsqd - dial tcp 8.8.8.8:543: i/o timeout
06:35:43 ERR    1 [logs/nsq_to_nsq] Handler returned error (dial tcp 8.8.8.8:543: i/o timeout) for msg 07d0d6da0313001f
06:35:43 INF    2 (this.is.a.cname.net:543) connecting to nsqd
06:35:43 WRN    1 [logs/nsq_to_nsq] backing off for 16.0000 seconds (backoff level 4), setting all to RDY 0
06:35:44 ERR    2 (this.is.a.cname.net:543) error connecting to nsqd - dial tcp 8.8.8.8:543: i/o timeout
06:35:44 ERR    1 [logs/nsq_to_nsq] Handler returned error (dial tcp 8.8.8.8:543: i/o timeout) for msg 07d0d6da03130020
06:35:44 INF    2 (this.is.a.cname.net:543) connecting to nsqd
06:35:45 ERR    2 (this.is.a.cname.net:543) error connecting to nsqd - dial tcp 8.8.8.8:543: i/o timeout
06:35:45 ERR    1 [logs/nsq_to_nsq] Handler returned error (dial tcp 8.8.8.8:543: i/o timeout) for msg 07d0d6da03130021
06:35:45 INF    2 (this.is.a.cname.net:543) connecting to nsqd
06:35:46 ERR    2 (this.is.a.cname.net:543) error connecting to nsqd - dial tcp 8.8.8.8:543: i/o timeout
06:35:46 ERR    1 [logs/nsq_to_nsq] Handler returned error (dial tcp 8.8.8.8:543: i/o timeout) for msg 07d0d6da03130022
06:35:46 INF    2 (this.is.a.cname.net:543) connecting to nsqd
06:35:47 ERR    2 (this.is.a.cname.net:543) error connecting to nsqd - dial tcp 8.8.8.8:543: i/o timeout
06:35:47 ERR    1 [logs/nsq_to_nsq] Handler returned error (dial tcp 8.8.8.8:543: i/o timeout) for msg 07d0d6da03130023
06:35:47 INF    2 (this.is.a.cname.net:543) connecting to nsqd
06:35:48 ERR    2 (this.is.a.cname.net:543) error connecting to nsqd - dial tcp 8.8.8.8:543: i/o timeout
06:35:48 ERR    1 [logs/nsq_to_nsq] Handler returned error (dial tcp 8.8.8.8:543: i/o timeout) for msg 07d0d6da03130024
06:35:48 INF    2 (this.is.a.cname.net:543) connecting to nsqd
06:35:49 ERR    2 (this.is.a.cname.net:543) error connecting to nsqd - dial tcp 8.8.8.8:543: i/o timeout
06:35:49 ERR    1 [logs/nsq_to_nsq] Handler returned error (dial tcp 8.8.8.8:543: i/o timeout) for msg 07d0d6da03130025
06:35:49 INF    2 (this.is.a.cname.net:543) connecting to nsqd
06:35:50 ERR    2 (this.is.a.cname.net:543) error connecting to nsqd - dial tcp 8.8.8.8:543: i/o timeout
06:35:50 ERR    1 [logs/nsq_to_nsq] Handler returned error (dial tcp 8.8.8.8:543: i/o timeout) for msg 07d0d6da03130026
06:35:50 INF    2 (this.is.a.cname.net:543) connecting to nsqd
06:35:51 ERR    2 (this.is.a.cname.net:543) error connecting to nsqd - dial tcp 8.8.8.8:543: i/o timeout
06:35:51 ERR    1 [logs/nsq_to_nsq] Handler returned error (dial tcp 8.8.8.8:543: i/o timeout) for msg 07d0d6da03130027
06:35:51 INF    2 (this.is.a.cname.net:543) connecting to nsqd
06:35:52 ERR    2 (this.is.a.cname.net:543) error connecting to nsqd - dial tcp 8.8.8.8:543: i/o timeout
06:35:52 ERR    1 [logs/nsq_to_nsq] Handler returned error (dial tcp 8.8.8.8:543: i/o timeout) for msg 07d0d6da03130028
06:35:52 INF    2 (this.is.a.cname.net:543) connecting to nsqd
06:35:53 ERR    2 (this.is.a.cname.net:543) error connecting to nsqd - dial tcp 8.8.8.8:543: i/o timeout
06:35:53 ERR    1 [logs/nsq_to_nsq] Handler returned error (dial tcp 8.8.8.8:543: i/o timeout) for msg 07d0d6da03130029
06:35:53 INF    2 (this.is.a.cname.net:543) connecting to nsqd
06:35:54 ERR    2 (this.is.a.cname.net:543) error connecting to nsqd - dial tcp 8.8.8.8:543: i/o timeout
06:35:54 ERR    1 [logs/nsq_to_nsq] Handler returned error (dial tcp 8.8.8.8:543: i/o timeout) for msg 07d0d6da0313002a
06:35:54 INF    2 (this.is.a.cname.net:543) connecting to nsqd
06:35:55 ERR    2 (this.is.a.cname.net:543) error connecting to nsqd - dial tcp 8.8.8.8:543: i/o timeout
06:35:55 ERR    1 [logs/nsq_to_nsq] Handler returned error (dial tcp 8.8.8.8:543: i/o timeout) for msg 07d0d6da0313002b
06:35:55 INF    2 (this.is.a.cname.net:543) connecting to nsqd
06:35:56 ERR    2 (this.is.a.cname.net:543) error connecting to nsqd - dial tcp 8.8.8.8:543: i/o timeout
06:35:56 ERR    1 [logs/nsq_to_nsq] Handler returned error (dial tcp 8.8.8.8:543: i/o timeout) for msg 07d0d6da0313002c
06:35:56 INF    2 (this.is.a.cname.net:543) connecting to nsqd
06:35:57 ERR    2 (this.is.a.cname.net:543) error connecting to nsqd - dial tcp 8.8.8.8:543: i/o timeout
06:35:57 ERR    1 [logs/nsq_to_nsq] Handler returned error (dial tcp 8.8.8.8:543: i/o timeout) for msg 07d0d6da0313002d
06:35:57 INF    2 (this.is.a.cname.net:543) connecting to nsqd
06:35:58 ERR    2 (this.is.a.cname.net:543) error connecting to nsqd - dial tcp 8.8.8.8:543: i/o timeout
06:35:58 ERR    1 [logs/nsq_to_nsq] Handler returned error (dial tcp 8.8.8.8:543: i/o timeout) for msg 07d0d6da0313002e
06:35:58 INF    2 (this.is.a.cname.net:543) connecting to nsqd
06:35:59 WRN    1 [logs/nsq_to_nsq] (localhost:543) backoff timeout expired, sending RDY 1
06:35:59 ERR    2 (this.is.a.cname.net:543) error connecting to nsqd - dial tcp 8.8.8.8:543: i/o timeout
06:35:59 ERR    1 [logs/nsq_to_nsq] Handler returned error (dial tcp 8.8.8.8:543: i/o timeout) for msg 07d0d6da0313002f
06:35:59 INF    2 (this.is.a.cname.net:543) connecting to nsqd
06:35:59 WRN    1 [logs/nsq_to_nsq] backing off for 32.0000 seconds (backoff level 5), setting all to RDY 0
06:36:00 ERR    2 (this.is.a.cname.net:543) error connecting to nsqd - dial tcp 8.8.8.8:543: i/o timeout
06:36:00 ERR    1 [logs/nsq_to_nsq] Handler returned error (dial tcp 8.8.8.8:543: i/o timeout) for msg 07d0d6da03130030
06:36:00 INF    2 (this.is.a.cname.net:543) connecting to nsqd
06:36:01 ERR    2 (this.is.a.cname.net:543) error connecting to nsqd - dial tcp 8.8.8.8:543: i/o timeout
06:36:01 ERR    1 [logs/nsq_to_nsq] Handler returned error (dial tcp 8.8.8.8:543: i/o timeout) for msg 07d0d6da03130031
06:36:01 INF    2 (this.is.a.cname.net:543) connecting to nsqd
06:36:02 ERR    2 (this.is.a.cname.net:543) error connecting to nsqd - dial tcp 8.8.8.8:543: i/o timeout
06:36:02 ERR    1 [logs/nsq_to_nsq] Handler returned error (dial tcp 8.8.8.8:543: i/o timeout) for msg 07d0d6da03130032
06:36:02 INF    2 (this.is.a.cname.net:543) connecting to nsqd
06:36:03 ERR    2 (this.is.a.cname.net:543) error connecting to nsqd - dial tcp 8.8.8.8:543: i/o timeout
06:36:03 ERR    1 [logs/nsq_to_nsq] Handler returned error (dial tcp 8.8.8.8:543: i/o timeout) for msg 07d0d6da03130033
06:36:03 INF    2 (this.is.a.cname.net:543) connecting to nsqd
06:36:04 ERR    2 (this.is.a.cname.net:543) error connecting to nsqd - dial tcp 8.8.8.8:543: i/o timeout
06:36:04 ERR    1 [logs/nsq_to_nsq] Handler returned error (dial tcp 8.8.8.8:543: i/o timeout) for msg 07d0d6da03130034
06:36:04 INF    2 (this.is.a.cname.net:543) connecting to nsqd
06:36:05 ERR    2 (this.is.a.cname.net:543) error connecting to nsqd - dial tcp 8.8.8.8:543: i/o timeout
06:36:05 ERR    1 [logs/nsq_to_nsq] Handler returned error (dial tcp 8.8.8.8:543: i/o timeout) for msg 07d0d6da03130035
06:36:05 INF    2 (this.is.a.cname.net:543) connecting to nsqd
06:36:06 ERR    2 (this.is.a.cname.net:543) error connecting to nsqd - dial tcp 8.8.8.8:543: i/o timeout
06:36:06 ERR    1 [logs/nsq_to_nsq] Handler returned error (dial tcp 8.8.8.8:543: i/o timeout) for msg 07d0d6da03130036
06:36:06 INF    2 (this.is.a.cname.net:543) connecting to nsqd
06:36:07 ERR    2 (this.is.a.cname.net:543) error connecting to nsqd - dial tcp 8.8.8.8:543: i/o timeout
06:36:07 ERR    1 [logs/nsq_to_nsq] Handler returned error (dial tcp 8.8.8.8:543: i/o timeout) for msg 07d0d6da03130037
06:36:07 INF    2 (this.is.a.cname.net:543) connecting to nsqd
06:36:08 ERR    2 (this.is.a.cname.net:543) error connecting to nsqd - dial tcp 8.8.8.8:543: i/o timeout
06:36:08 ERR    1 [logs/nsq_to_nsq] Handler returned error (dial tcp 8.8.8.8:543: i/o timeout) for msg 07d0d6da03130038
06:36:08 INF    2 (this.is.a.cname.net:543) connecting to nsqd
06:36:09 ERR    2 (this.is.a.cname.net:543) error connecting to nsqd - dial tcp 8.8.8.8:543: i/o timeout
06:36:09 ERR    1 [logs/nsq_to_nsq] Handler returned error (dial tcp 8.8.8.8:543: i/o timeout) for msg 07d0d6da03130039
06:36:09 INF    2 (this.is.a.cname.net:543) connecting to nsqd
06:36:09 INF    2 (this.is.a.cname.net:543) upgrading to TLS
06:36:31 WRN    1 [logs/nsq_to_nsq] (localhost:543) backoff timeout expired, sending RDY 1
06:37:10 ERR    1 [logs/nsq_to_nsq] (localhost:543) IO error - read tcp 127.0.0.1:543: i/o timeout
06:37:10 INF    1 [logs/nsq_to_nsq] (localhost:543) beginning close
06:37:10 INF    1 [logs/nsq_to_nsq] (localhost:543) readLoop exiting
06:37:10 INF    1 [logs/nsq_to_nsq] (localhost:543) breaking out of writeLoop
06:37:10 INF    1 [logs/nsq_to_nsq] (localhost:543) writeLoop exiting
06:37:10 INF    1 [logs/nsq_to_nsq] (localhost:543) finished draining, cleanup exiting
06:37:10 INF    1 [logs/nsq_to_nsq] (localhost:543) clean close complete
06:37:10 WRN    1 [logs/nsq_to_nsq] there are 0 connections left alive
06:37:10 INF    1 [logs/nsq_to_nsq] (127.0.0.1:543) re-connecting in 15 seconds...
06:37:25 WRN    1 [logs/nsq_to_nsq] (127.0.0.1:543) skipped reconnect after removal...
```

nsqd logs:
```
06:35:27.890380 TCP: new client(127.0.0.1:49134)
06:35:27.890414 CLIENT(127.0.0.1:49134): desired protocol magic '  V2'
06:35:27.890710 [127.0.0.1:49134] IDENTIFY: {ShortId:myserver-2 LongId:myserver-2 ClientID:myserver-2 Hostname:myserver-2 HeartbeatInterval:30000 OutputBufferSize:16384 OutputBufferTimeout:250 FeatureNegotiation:true TLSv1:true Deflate:false DeflateLevel:6 Snappy:false SampleRate:0 UserAgent:nsq_to_nsq/0.3.1 go-nsq/1.0.2 MsgTimeout:0}
06:35:27.890805 PROTOCOL(V2): [127.0.0.1:49134] upgrading connection to TLS
06:35:58.068237 PROTOCOL(V2): [127.0.0.1:49134] exiting messagePump
06:35:58.068270 PROTOCOL(V2): [127.0.0.1:49134] messagePump error - write tcp 127.0.0.1:49134: i/o timeout
06:37:10.193589 PROTOCOL(V2): [127.0.0.1:49134] exiting ioloop
06:37:10.193661 ERROR: client(127.0.0.1:49134) - failed to read command - EOF
```

Initially, the destination nsqd was unreachable, but it did become reachable towards the end of the logs and this is visible with `06:36:09 INF    2 (this.is.a.cname.net:543) connecting to nsqd`. However, after becoming reachable, nsq_to_nsq noped right out of sending messages and stopped.

@jehiah thinks "there might be a subtle detail there with it using the resolved address in one spot an the hostname in another"

specifically here: https://github.com/bitly/go-nsq/blob/cfa41b99b4efed4f19d990d6d1eb60f0e30a4062/consumer.go#L766