### PR TITLE
consumer: jitter might have no effect

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -363,13 +363,15 @@ func (r *Consumer) lookupdLoop() {
 	// when restarted at the same time, dont all connect at once.
 	jitter := time.Duration(int64(r.rng.Float64() *
 		r.config.LookupdPollJitter * float64(r.config.LookupdPollInterval)))
-	ticker := time.NewTicker(r.config.LookupdPollInterval)
+	var ticker *time.Ticker
 
 	select {
 	case <-time.After(jitter):
 	case <-r.exitChan:
 		goto exit
 	}
+
+	ticker = time.NewTicker(r.config.LookupdPollInterval)
 
 	for {
 		select {
@@ -383,7 +385,9 @@ func (r *Consumer) lookupdLoop() {
 	}
 
 exit:
-	ticker.Stop()
+	if ticker != nil {
+		ticker.Stop()
+	}
 	r.log(LogLevelInfo, "exiting lookupdLoop")
 	r.wg.Done()
 }


### PR DESCRIPTION
ticker starts when it's created. when it's created before waiting on jitter the jitter has no effect, unless jitter is greater than the tick interval.

example:

    start := time.Now()

    ticker := time.NewTicker(1500 * time.Millisecond)
    time.Sleep(1000 * time.Millisecond)

    <-ticker.C

    fmt.Println(time.Now().Sub(start))

original PR was closed with rebase (oops) https://github.com/bitly/go-nsq/pull/113