### PR TITLE
remove unnecessary check on pendingOk

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -510,9 +510,7 @@ func (r *Consumer) ConnectToNSQD(addr string) error {
 		r.mtx.Unlock()
 		return ErrAlreadyConnected
 	}
-	if !pendingOk {
-		r.pendingConnections[addr] = conn
-	}
+	r.pendingConnections[addr] = conn
 	if idx := indexOf(addr, r.nsqdTCPAddrs); idx == -1 {
 		r.nsqdTCPAddrs = append(r.nsqdTCPAddrs, addr)
 	}


### PR DESCRIPTION
see above if statement: if ok || pendingOk { r.mtx.Unlock() return ErrAlreadyConnected }