### PR TITLE
producer: Adds a Ping method in order to validate an nsqd connection

### DIFF
--- a/producer.go
+++ b/producer.go
@@ -91,6 +91,23 @@ func NewProducer(addr string, config *Config) (*Producer, error) {
 	return p, nil
 }
 
+// Ping causes the Producer to connect to it's configured nsqd (if not already
+// connected) and send a `Nop` command, returning any error that might occur.
+//
+// This method can be used to verify that a newly-created Producer instance is
+// configured correctly, rather than relying on the lazy "connect on Publish"
+// behavior of a Producer.
+func (w *Producer) Ping() error {
+	if atomic.LoadInt32(&w.state) != StateConnected {
+		err := w.connect()
+		if err != nil {
+			return err
+		}
+	}
+
+	return w.conn.WriteCommand(Nop())
+}
+
 // SetLogger assigns the logger to use as well as a level
 //
 // The logger parameter is an interface that requires the following

--- a/producer_test.go
+++ b/producer_test.go
@@ -3,6 +3,9 @@ package nsq
 import (
 	"bytes"
 	"errors"
+	"io/ioutil"
+	"log"
+	"os"
 	"runtime"
 	"strconv"
 	"sync"
@@ -50,6 +53,28 @@ func TestProducerConnection(t *testing.T) {
 	err = w.Publish("write_test", []byte("fail test"))
 	if err != ErrStopped {
 		t.Fatalf("should not be able to write after Stop()")
+	}
+}
+
+func TestProducerPing(t *testing.T) {
+	log.SetOutput(ioutil.Discard)
+	defer log.SetOutput(os.Stdout)
+
+	config := NewConfig()
+	w, _ := NewProducer("127.0.0.1:4150", config)
+	w.SetLogger(nullLogger, LogLevelInfo)
+
+	err := w.Ping()
+
+	if err != nil {
+		t.Fatalf("should connect on ping")
+	}
+
+	w.Stop()
+
+	err = w.Ping()
+	if err != ErrStopped {
+		t.Fatalf("should not be able to ping after Stop()")
 	}
 }
 


### PR DESCRIPTION
Adds a Ping method to the Producer, which allows for testing a Producer's nsqd connection w/o publishing any messages to a topic. 

I've found it to be useful for failing fast when configuring Producers that might not Publish immediately (since otherwise, the connections are only made lazily on Publish).

Not thrilled with the method name "Ping", so am totally open to other suggestions.