### PR TITLE
producer: buffer transaction chan

### DIFF
--- a/command_test.go
+++ b/command_test.go
@@ -2,16 +2,11 @@ package nsq
 
 import (
 	"bytes"
-	"io/ioutil"
-	"log"
-	"os"
 	"testing"
 )
 
 func BenchmarkCommand(b *testing.B) {
 	b.StopTimer()
-	log.SetOutput(ioutil.Discard)
-	defer log.SetOutput(os.Stdout)
 	data := make([]byte, 2048)
 	cmd := Publish("test", data)
 	var buf bytes.Buffer

--- a/mock_test.go
+++ b/mock_test.go
@@ -10,7 +10,6 @@ import (
 	"io/ioutil"
 	"log"
 	"net"
-	"os"
 	"strconv"
 	"testing"
 	"time"
@@ -182,9 +181,6 @@ func (h *testHandler) HandleMessage(message *Message) error {
 }
 
 func TestConsumerBackoff(t *testing.T) {
-	log.SetOutput(ioutil.Discard)
-	defer log.SetOutput(os.Stdout)
-
 	logger := log.New(ioutil.Discard, "", log.LstdFlags)
 
 	var mgood bytes.Buffer

--- a/producer.go
+++ b/producer.go
@@ -9,6 +9,14 @@ import (
 	"time"
 )
 
+type producerConn interface {
+	String() string
+	SetLogger(logger, LogLevel, string)
+	Connect() (*IdentifyResponse, error)
+	Close() error
+	WriteCommand(*Command) error
+}
+
 // Producer is a high-level type to publish to NSQ.
 //
 // A Producer instance is 1:1 with a destination `nsqd`
@@ -17,7 +25,7 @@ import (
 type Producer struct {
 	id     int64
 	addr   string
-	conn   *Conn
+	conn   producerConn
 	config Config
 
 	logger   logger

--- a/producer_test.go
+++ b/producer_test.go
@@ -2,9 +2,6 @@ package nsq
 
 import (
 	"errors"
-	"io/ioutil"
-	"log"
-	"os"
 	"strconv"
 	"testing"
 	"time"
@@ -35,9 +32,6 @@ func (h *ConsumerHandler) HandleMessage(message *Message) error {
 }
 
 func TestProducerConnection(t *testing.T) {
-	log.SetOutput(ioutil.Discard)
-	defer log.SetOutput(os.Stdout)
-
 	config := NewConfig()
 	w, _ := NewProducer("127.0.0.1:4150", config)
 	w.SetLogger(nullLogger, LogLevelInfo)
@@ -56,9 +50,6 @@ func TestProducerConnection(t *testing.T) {
 }
 
 func TestProducerPublish(t *testing.T) {
-	log.SetOutput(ioutil.Discard)
-	defer log.SetOutput(os.Stdout)
-
 	topicName := "publish" + strconv.Itoa(int(time.Now().Unix()))
 	msgCount := 10
 
@@ -83,9 +74,6 @@ func TestProducerPublish(t *testing.T) {
 }
 
 func TestProducerMultiPublish(t *testing.T) {
-	log.SetOutput(ioutil.Discard)
-	defer log.SetOutput(os.Stdout)
-
 	topicName := "multi_publish" + strconv.Itoa(int(time.Now().Unix()))
 	msgCount := 10
 
@@ -113,9 +101,6 @@ func TestProducerMultiPublish(t *testing.T) {
 }
 
 func TestProducerPublishAsync(t *testing.T) {
-	log.SetOutput(ioutil.Discard)
-	defer log.SetOutput(os.Stdout)
-
 	topicName := "async_publish" + strconv.Itoa(int(time.Now().Unix()))
 	msgCount := 10
 
@@ -151,9 +136,6 @@ func TestProducerPublishAsync(t *testing.T) {
 }
 
 func TestProducerMultiPublishAsync(t *testing.T) {
-	log.SetOutput(ioutil.Discard)
-	defer log.SetOutput(os.Stdout)
-
 	topicName := "multi_publish" + strconv.Itoa(int(time.Now().Unix()))
 	msgCount := 10
 
@@ -193,9 +175,6 @@ func TestProducerMultiPublishAsync(t *testing.T) {
 }
 
 func TestProducerHeartbeat(t *testing.T) {
-	log.SetOutput(ioutil.Discard)
-	defer log.SetOutput(os.Stdout)
-
 	topicName := "heartbeat" + strconv.Itoa(int(time.Now().Unix()))
 
 	config := NewConfig()


### PR DESCRIPTION
There's no reason for `transactionChan` to be unbuffered, it forces
the `router()` goroutine to work in lock-step with publishing, slowing
things down.

I should probably do some benchmarks.

cc @jehiah