### PR TITLE
when in backoff, make sure that the chosen connection isn't closing

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -13,6 +13,9 @@ var ErrNotConnected = errors.New("not connected")
 // made against a Producer that has been stopped
 var ErrStopped = errors.New("stopped")
 
+// ErrClosing is returned when a connection is closing
+var ErrClosing = errors.New("closing")
+
 // ErrAlreadyConnected is returned from ConnectToNSQD when already connected
 var ErrAlreadyConnected = errors.New("already connected")
 


### PR DESCRIPTION
Backoff chooses a random connection and tries to update the ready status; however, if the connection is closing, updateRdy will return immediately, leaving the backoffCounter in a bad state. The side effect is that maybeUpdateRdy will never update the ready count due to the incorrect backoffCounter and the consumer will never again consume messages.