### PR TITLE
Allow backoff to be completely disabled in consumer

### DIFF
--- a/config.go
+++ b/config.go
@@ -118,6 +118,8 @@ type Config struct {
 	MaxRequeueDelay     time.Duration `opt:"max_requeue_delay" min:"0" max:"60m" default:"15m"`
 	DefaultRequeueDelay time.Duration `opt:"default_requeue_delay" min:"0" max:"60m" default:"90s"`
 
+	// Backoff enabled, defaults to true. Setting this to false disables backoff entirely.
+	BackoffEnabled bool `opt:"backoff_enabled" default:"true"`
 	// Backoff strategy, defaults to exponential backoff. Overwrite this to define alternative backoff algrithms.
 	BackoffStrategy BackoffStrategy `opt:"backoff_strategy" default:"exponential"`
 	// Maximum amount of time to backoff when processing fails 0 == no backoff

--- a/config_test.go
+++ b/config_test.go
@@ -44,6 +44,15 @@ func TestConfigSet(t *testing.T) {
 	if c.LocalAddr.String() != "1.2.3.4:27015" {
 		t.Error("Failed to assign `local_addr` config")
 	}
+	if c.BackoffEnabled != true {
+		t.Errorf("Failed to set default `true` backoff_enabled")
+	}
+	if err := c.Set("backoff_enabled", "false"); err != nil {
+		t.Error("Error setting `backoff_strategy` config: %s", err)
+	}
+	if c.BackoffEnabled != false {
+		t.Errorf("Failed to set `false` backoff_enabled")
+	}
 	if reflect.ValueOf(c.BackoffStrategy).Type().String() != "*nsq.ExponentialStrategy" {
 		t.Error("Failed to set default `exponential` backoff strategy")
 	}

--- a/consumer.go
+++ b/consumer.go
@@ -642,6 +642,11 @@ func (r *Consumer) onConnResume(c *Conn) {
 }
 
 func (r *Consumer) startStopContinueBackoff(conn *Conn, success bool) {
+	// allows backoff to be completely disabled
+	if !r.config.BackoffEnabled {
+		return
+	}
+
 	// prevent many async failures/successes from immediately resulting in
 	// max backoff/normal rate (by ensuring that we dont continually incr/decr
 	// the counter during a backoff period)


### PR DESCRIPTION
This pull request adds a `backoff_enabled` option to Config with the default value being set to true. When disabled, the consumer will never back off.

This is different from setting a `backoff_duration` of 0, as in that case the consumer will still send `RDY 0` to nsqd, decreasing throughput significantly. Disabling the `backoff_enabled` option allows us to sustain high throughput when messages are failing.

There were quite a few ways to implement this - I went with the simplest to read and probably most efficient rather than complicating the existing backoff logic and/or inflating the BackoffStrategy interface. The new configuration option has a nice side effect of not changing the existing behavior for anyone who might have `backoff_duration` set to 0 then suddenly see their throughput increase under error conditions.

I'm not sure how to build an automated test for this.