### PR TITLE
update FullJitterStrategy Calculate to not bound by MaxBackoffDuration

### DIFF
--- a/config.go
+++ b/config.go
@@ -72,9 +72,6 @@ func (s *FullJitterStrategy) Calculate(attempt int) time.Duration {
 
 	backoffDuration := s.cfg.BackoffMultiplier *
 		time.Duration(math.Pow(2, float64(attempt)))
-	if backoffDuration > s.cfg.MaxBackoffDuration {
-		backoffDuration = s.cfg.MaxBackoffDuration
-	}
 	return time.Duration(s.rng.Intn(int(backoffDuration)))
 }
 


### PR DESCRIPTION
- responsibility has been moved to Consumer startStopContinueBackoff
- see PR #147 and #142